### PR TITLE
Ingore act_as_paranoid behavior if scorecard deleted_at field migration

### DIFF
--- a/app/models/scorecard.rb
+++ b/app/models/scorecard.rb
@@ -48,7 +48,7 @@ class Scorecard < ApplicationRecord
   include Scorecards::CallbackNotification
   include Scorecards::Elasticsearch
 
-  acts_as_paranoid
+  acts_as_paranoid if column_names.include? 'deleted_at'
 
   enum scorecard_type: {
     self_assessment: 1,


### PR DESCRIPTION
- Prevent act_as_paranoid to functioning only scorecard deleted_at field migration