### PR TITLE
Copilot/add testing label login page

### DIFF
--- a/app/assets/stylesheets/shared/ribbon.scss
+++ b/app/assets/stylesheets/shared/ribbon.scss
@@ -1,25 +1,40 @@
-.ribbon-wrapper {
-  width: 85px;
-  height: 88px;
+.testing-ribbon {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: 120px;
+  height: 120px;
   overflow: hidden;
+  z-index: 1000;
+  pointer-events: none; /* avoid blocking clicks */
+}
+
+.testing-ribbon span {
   position: absolute;
-  top: -3px;
-  left: -3px;
-  .ribbon {
-    font: bold 15px sans-serif;
-    text-align: center;
-    -webkit-transform: rotate(-45deg);
-    -moz-transform:    rotate(-45deg);
-    -ms-transform:     rotate(-45deg);
-    -o-transform:      rotate(-45deg);
-    position: relative;
-    padding: 7px 0;
-    top: 15px;
-    left: -30px;
-    width: 120px;
-    background-color: #fadbd8;
-    color: #78261f;
-    border-color: #f8ccc8;
-    line-height: 18px;
+  top: 24px;
+  right: -32px;
+  width: 140px;
+  padding: 6px 0;
+  color: #78261f;
+  background-color: #fadbd8;
+  border: 1px solid #f8ccc8;
+  text-align: center;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 1px;
+  transform: rotate(45deg);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.25);
+}
+
+@media (max-width: 480px) {
+  .testing-ribbon {
+    width: 90px;
+    height: 90px;
+  }
+
+  .testing-ribbon span {
+    top: 18px;
+    right: -38px;
+    font-size: 10px;
   }
 }

--- a/app/views/layouts/minimal.html.haml
+++ b/app/views/layouts/minimal.html.haml
@@ -17,6 +17,7 @@
     = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
 
   %body.devise-form
+    = render "shared/testing_mode_ribbon"
     = render "shared/notify_message"
 
     .column

--- a/app/views/shared/_testing_mode_ribbon.haml
+++ b/app/views/shared/_testing_mode_ribbon.haml
@@ -1,0 +1,3 @@
+- if test_mode?
+  .testing-ribbon
+    %span= t('shared.testing')


### PR DESCRIPTION
Adds a minimal corner ribbon to the login page indicating when the app is in testing mode, making the environment immediately obvious to users.

## Changes

- **New partial**: `_testing_mode_ribbon.haml` displays "TESTING" when `test_mode?`
- **CSS ribbon**: Red diagonal banner positioned top-right with fixed positioning (z-index 1000)
- **Responsive breakpoints**: Font and padding scale down at 480px
- **Layout integration**: Added to `minimal.html.haml` layout

## Screenshots

**Desktop**  
<img width="500" height="278" alt="Screenshot 2025-12-25 at 9 10 10 AM" src="https://github.com/user-attachments/assets/bb6ff34a-7d4b-4d89-9adf-904781fa3eaa" />


**Mobile (480px)**  
<img width="259" height="459" alt="Screenshot 2025-12-25 at 9 02 16 AM" src="https://github.com/user-attachments/assets/baee7e9e-7587-4276-ae23-d79a3afb5c47" />
