### PR TITLE
Close #90 enhance scorecard api and use participant callback

### DIFF
--- a/app/controllers/api/v1/scorecards_controller.rb
+++ b/app/controllers/api/v1/scorecards_controller.rb
@@ -51,8 +51,7 @@ module Api
 
         def scorecard_params
           param = params.require(:scorecard).permit(
-            :conducted_date, :number_of_caf, :number_of_participant, :number_of_female,
-            :number_of_disability, :number_of_ethnic_minority, :number_of_youth, :number_of_id_poor,
+            :conducted_date, :number_of_caf,
             :finished_date, :language_conducted_code, :running_date, :device_type, :device_token,
             :proposed_indicator_method, :number_of_anonymous, :device_id, :app_version,
             facilitators_attributes: [ :id, :caf_id, :position ],

--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -17,18 +17,26 @@
 #  countable      :boolean          default(TRUE)
 #
 class Participant < ApplicationRecord
+  # Associations
   belongs_to :scorecard, foreign_key: :scorecard_uuid, optional: true
 
+  # Callback
   before_create :secure_uuid
+  after_commit :increase_scorecard_participant_count, on: :create
+  after_commit :decrease_scorecard_participant_count, on: :destroy
 
+  # Constants
   GENDERS=%w(female male other)
   GENDER_MALE = "male"
   GENDER_FEMALE = "female"
   GENDER_OTHER = "other"
 
-  scope :males, -> { where(gender: :male) }
-  scope :others, -> { where(gender: :other) }
+  # Scopes
+  scope :males,  -> { where(gender: GENDER_MALE) }
+  scope :others, -> { where(gender: GENDER_OTHER) }
+  scope :females, -> { where(gender: GENDER_FEMALE) }
 
+  # Instance Methods
   def female?
     gender == GENDER_FEMALE
   end
@@ -36,4 +44,33 @@ class Participant < ApplicationRecord
   def male?
     gender == GENDER_MALE
   end
+
+  private
+    def increase_scorecard_participant_count
+      return unless countable? && scorecard.present?
+
+      Scorecard.update_counters(
+        scorecard.id,
+        number_of_participant: 1,
+        number_of_female: (female? ? 1 : 0),
+        number_of_youth: (youth? ? 1 : 0),
+        number_of_disability: (disability? ? 1 : 0),
+        number_of_ethnic_minority: (minority? ? 1 : 0),
+        number_of_id_poor: (poor_card? ? 1 : 0)
+      )
+    end
+
+    def decrease_scorecard_participant_count
+      return unless countable? && scorecard.present?
+
+      Scorecard.update_counters(
+        scorecard.id,
+        number_of_participant: -1,
+        number_of_female: (female? ? -1 : 0),
+        number_of_youth: (youth? ? -1 : 0),
+        number_of_disability: (disability? ? -1 : 0),
+        number_of_ethnic_minority: (minority? ? -1 : 0),
+        number_of_id_poor: (poor_card? ? -1 : 0)
+      )
+    end
 end

--- a/app/services/scorecards/normalize_params_to_update_service.rb
+++ b/app/services/scorecards/normalize_params_to_update_service.rb
@@ -9,40 +9,11 @@ module Scorecards
 
     def call
       normalize_voting_indicator_params
-      normalize_participant_demographics_params
       params
     end
 
     private
       attr_reader :scorecard, :params
-
-      def normalize_participant_demographics_params
-        return unless scorecard.online?
-
-        # merge results into params with integer coercion
-        params.merge!(
-          number_of_participant: participant_counts.total.to_i,
-          number_of_female: participant_counts.female_count.to_i,
-          number_of_disability: participant_counts.disability_count.to_i,
-          number_of_ethnic_minority: participant_counts.minority_count.to_i,
-          number_of_youth: participant_counts.youth_count.to_i,
-          number_of_id_poor: participant_counts.poor_count.to_i
-        )
-      end
-
-      def participant_counts
-        @participant_counts ||= scorecard.participants
-          .where(countable: true)
-          .select(
-            "COUNT(*) AS total",
-            "SUM((gender = 'female')::int) AS female_count",
-            "SUM(disability::int) AS disability_count",
-            "SUM(minority::int) AS minority_count",
-            "SUM(youth::int) AS youth_count",
-            "SUM(poor_card::int) AS poor_count"
-          )
-          .take
-      end
 
       def normalize_voting_indicator_params
         return unless voting_indicators_params.present?

--- a/spec/models/participant_spec.rb
+++ b/spec/models/participant_spec.rb
@@ -19,5 +19,164 @@
 require "rails_helper"
 
 RSpec.describe Participant, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "associations" do
+    it { is_expected.to belong_to(:scorecard).optional }
+  end
+
+  describe "gender helpers" do
+    it "returns true for female? when gender is female" do
+      participant = build(:participant, gender: Participant::GENDER_FEMALE)
+      expect(participant.female?).to be(true)
+      expect(participant.male?).to be(false)
+    end
+
+    it "returns true for male? when gender is male" do
+      participant = build(:participant, gender: Participant::GENDER_MALE)
+      expect(participant.male?).to be(true)
+      expect(participant.female?).to be(false)
+    end
+  end
+
+  describe "scopes" do
+    it "filters by genders" do
+      female = create(:participant, gender: Participant::GENDER_FEMALE)
+      male   = create(:participant, gender: Participant::GENDER_MALE)
+      other  = create(:participant, gender: Participant::GENDER_OTHER)
+
+      expect(Participant.females).to include(female)
+      expect(Participant.males).to include(male)
+      expect(Participant.others).to include(other)
+    end
+  end
+
+  describe "counter increments on create" do
+    it "increments scorecard counters when a countable participant is created" do
+      scorecard = create(:scorecard,
+        number_of_participant: 0,
+        number_of_female: 0,
+        number_of_youth: 0,
+        number_of_disability: 0,
+        number_of_ethnic_minority: 0,
+        number_of_id_poor: 0
+      )
+
+      create(:participant,
+        scorecard: scorecard,
+        gender: Participant::GENDER_FEMALE,
+        youth: true,
+        disability: true,
+        minority: true,
+        poor_card: true,
+        countable: true
+      )
+
+      sc = scorecard.reload
+      expect(sc.number_of_participant).to eq(1)
+      expect(sc.number_of_female).to eq(1)
+      expect(sc.number_of_youth).to eq(1)
+      expect(sc.number_of_disability).to eq(1)
+      expect(sc.number_of_ethnic_minority).to eq(1)
+      expect(sc.number_of_id_poor).to eq(1)
+    end
+
+    it "does not increment counters when participant is not countable" do
+      scorecard = create(:scorecard,
+        number_of_participant: 0,
+        number_of_female: 0
+      )
+
+      create(:participant,
+        scorecard: scorecard,
+        gender: Participant::GENDER_FEMALE,
+        countable: false
+      )
+
+      sc = scorecard.reload
+      expect(sc.number_of_participant.to_i).to eq(0)
+      expect(sc.number_of_female.to_i).to eq(0)
+    end
+  end
+
+  describe "nested attributes with scorecard" do
+    it "increments counters when participants are created via nested attributes" do
+      scorecard = create(:scorecard,
+        number_of_participant: 0,
+        number_of_female: 0,
+        number_of_youth: 0,
+        number_of_disability: 0,
+        number_of_ethnic_minority: 0,
+        number_of_id_poor: 0
+      )
+
+      scorecard.update!(
+        participants_attributes: [
+          {
+            gender: Participant::GENDER_FEMALE,
+            youth: true,
+            disability: false,
+            minority: true,
+            poor_card: false,
+            countable: true
+          },
+          {
+            gender: Participant::GENDER_MALE,
+            youth: false,
+            disability: true,
+            minority: false,
+            poor_card: true,
+            countable: true
+          }
+        ]
+      )
+
+      sc = scorecard.reload
+      expect(sc.number_of_participant).to eq(2)
+      expect(sc.number_of_female).to eq(1)
+      expect(sc.number_of_youth).to eq(1)
+      expect(sc.number_of_disability).to eq(1)
+      expect(sc.number_of_ethnic_minority).to eq(1)
+      expect(sc.number_of_id_poor).to eq(1)
+    end
+  end
+
+  describe "counter decrements on destroy" do
+    it "decrements scorecard counters when a countable participant is destroyed" do
+      scorecard = create(:scorecard,
+        number_of_participant: 0,
+        number_of_female: 0,
+        number_of_youth: 0,
+        number_of_disability: 0,
+        number_of_ethnic_minority: 0,
+        number_of_id_poor: 0
+      )
+
+      participant = create(:participant,
+        scorecard: scorecard,
+        gender: Participant::GENDER_FEMALE,
+        youth: true,
+        disability: true,
+        minority: true,
+        poor_card: true,
+        countable: true
+      )
+
+      sc = scorecard.reload
+      expect(sc.number_of_participant).to eq(1)
+      expect(sc.number_of_female).to eq(1)
+      expect(sc.number_of_youth).to eq(1)
+      expect(sc.number_of_disability).to eq(1)
+      expect(sc.number_of_ethnic_minority).to eq(1)
+      expect(sc.number_of_id_poor).to eq(1)
+
+      participant.destroy
+
+      sc = scorecard.reload
+      expect(sc.number_of_participant).to eq(0)
+      expect(sc.number_of_female).to eq(0)
+      expect(sc.number_of_youth).to eq(0)
+      expect(sc.number_of_disability).to eq(0)
+      expect(sc.number_of_ethnic_minority).to eq(0)
+      expect(sc.number_of_id_poor).to eq(0)
+    end
+  end
 end

--- a/spec/services/scorecards/normalize_params_to_update_service_spec.rb
+++ b/spec/services/scorecards/normalize_params_to_update_service_spec.rb
@@ -52,44 +52,5 @@ RSpec.describe Scorecards::NormalizeParamsToUpdateService do
         expect(result[:some]).to eq("value")
       end
     end
-
-    context "participant demographics normalization" do
-      let!(:scorecard_online)  { create(:scorecard, running_mode: "online") }
-      let!(:scorecard_offline) { create(:scorecard, running_mode: "offline") }
-
-      it "merges computed demographics for online scorecards" do
-        # 3 countable participants and 1 non-countable
-        Participant.create!(scorecard_uuid: scorecard_online.id, gender: "female", disability: true,  minority: true,  youth: true,  poor_card: false, countable: true)
-        Participant.create!(scorecard_uuid: scorecard_online.id, gender: "female", disability: false, minority: false, youth: true,  poor_card: true,  countable: true)
-        Participant.create!(scorecard_uuid: scorecard_online.id, gender: "male",   disability: false, minority: false, youth: false, poor_card: false, countable: true)
-        Participant.create!(scorecard_uuid: scorecard_online.id, gender: "female", disability: true,  minority: true,  youth: true,  poor_card: true,  countable: false)
-
-        # Provide conflicting values to ensure they get overridden
-        params = { number_of_participant: 999, number_of_female: 999 }
-        result = described_class.new(scorecard_online, params).call
-
-        expect(result[:number_of_participant]).to eq(3)
-        expect(result[:number_of_female]).to eq(2)
-        expect(result[:number_of_disability]).to eq(1)
-        expect(result[:number_of_ethnic_minority]).to eq(1)
-        expect(result[:number_of_youth]).to eq(2)
-        expect(result[:number_of_id_poor]).to eq(1)
-      end
-
-      it "does not override submitted demographics for offline scorecards" do
-        params = {
-          number_of_participant: 10,
-          number_of_female: 5,
-          number_of_disability: 2,
-          number_of_ethnic_minority: 1,
-          number_of_youth: 3,
-          number_of_id_poor: 4
-        }
-
-        result = described_class.new(scorecard_offline, params).call
-
-        expect(result).to include(params)
-      end
-    end
   end
 end


### PR DESCRIPTION
### Highlights

* **Refactored Participant Demographics Counting**: The logic for calculating and updating participant demographic counts (e.g., total participants, females, youth, disability) has been moved from the API controller/service layer to an `after_commit` callback within the `Participant` model. This ensures that scorecard demographic fields are automatically updated whenever a participant record is created.
* **Streamlined Scorecard API Parameters**: Direct submission of participant demographic fields (like `number_of_participant`, `number_of_female`) to the scorecard API is no longer permitted. These values are now derived and updated automatically based on the associated participant records.
* **Removed Redundant Service Logic**: The `NormalizeParamsToUpdateService` no longer contains logic for normalizing participant demographics, as this responsibility has been fully delegated to the `Participant` model's callback.
* **Enhanced Test Coverage**: Comprehensive tests have been added and updated across the `Participant` model, scorecard API requests, and related services to validate the new callback-driven demographic counting mechanism, including scenarios with nested attributes.